### PR TITLE
Increase key derivation rounds

### DIFF
--- a/source/config.js
+++ b/source/config.js
@@ -1,8 +1,8 @@
 module.exports = {
 
     DERIVED_KEY_ALGORITHM:                  "sha256",
-    DERIVED_KEY_ITERATIONS_MIN:             6000,
-    DERIVED_KEY_ITERATIONS_MAX:             8000,
+    DERIVED_KEY_ITERATIONS_MIN:             200000,
+    DERIVED_KEY_ITERATIONS_MAX:             250000,
     ENC_ALGORITHM:                          "aes-256-cbc",
     FILE_HASH_ALGORITHM:                    "sha256",
     HMAC_ALGORITHM:                         "sha256",


### PR DESCRIPTION
Security needs to be improved by increasing the minimum number of randomised PBKDF2 rounds. This update keeps them between 200-250k whilst retaining backwards compatibility.